### PR TITLE
Expand {{title}} for new notes created from templates

### DIFF
--- a/scripts/new-note.js
+++ b/scripts/new-note.js
@@ -41,7 +41,7 @@ function run (argv) {
 		let templateAbsPath = $.getenv("vault_path").replace(/^~/, app.pathTo("home folder"))
 			+ "/" + templateRelPath;
 		if (!templateAbsPath.endsWith(".md")) templateAbsPath += ".md";
-		newNoteContent += readFile(templateAbsPath);
+		newNoteContent += readFile(templateAbsPath).replace('{{title}}', fileName);
 		console.log("absolute template path:" + templateAbsPath);
 	}
 


### PR DESCRIPTION
This replaces `{{title}}` with the filename of the note when creating new notes created from templates.

I've omitted the date variables (see https://help.obsidian.md/Plugins/Templates) since they can be
configured in the Obsidian settings to have custom formats. Implementing them correctly (as opposed
to only supporting the default format) is a bit trickier than a one-line change.